### PR TITLE
Fixes #11 where camera didn't load if permission prompted

### DIFF
--- a/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
@@ -47,7 +47,12 @@ namespace UnityARInterface
                 gameObject.SetActive(true);
             }
 
-            m_Session.Connect();
+            m_Session.Connect().ThenAction((result) =>
+            {
+                // Must re-enable the ARController because if we needed to prompt for camera permission, we 
+                // will have returned below immediately and the ARController will have disabled itself.
+                ARController.FindObjectOfType<ARController>().enabled = true;
+            });
             return SessionManager.ConnectionState == SessionConnectionState.Connected;
         }
 


### PR DESCRIPTION
https://github.com/Unity-Technologies/experimental-ARInterface/blob/master/Assets/UnityARInterface/Scripts/ARCoreInterface.cs#L50 kicks off an async task, but then immediately returns (with status not yet connected) before the async task completes (ie. before user has granted permission on the shown prompt).

The caller, https://github.com/Unity-Technologies/experimental-ARInterface/blob/master/Assets/UnityARInterface/Scripts/ARController.cs#L117 gets the return value, serviceRunning = false, so prompty disables itself (https://github.com/Unity-Technologies/experimental-ARInterface/blob/master/Assets/UnityARInterface/Scripts/ARController.cs#L126) before starting to read from the camera (m_ARInterface.SetupCamera(m_ARCamera) is never called).

My fix re-enables the ARController once the user has granted the permission so that it can set up the camera, start listening for AR poses etc.

Perhaps there's a better way to get a reference to the ARController object than the global FindObjectOfType<ARController>()?