### PR TITLE
Interface improvements (#15)

### DIFF
--- a/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditor.cs
+++ b/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditor.cs
@@ -142,7 +142,7 @@ namespace UnityARInterface
                 message = string.Format("Connected to remote AR device: {0}", m_RemoteInterface.playerId);
                 var buttonRect = new Rect((Screen.width / 2) - 200, (Screen.height / 2) - 200, 400, 100);
 
-                if (m_RemoteInterface.serviceRunning)
+                if (m_RemoteInterface.IsRunning)
                 {
                     if (GUI.Button(buttonRect, "Stop Remote AR Session"))
                         m_RemoteInterface.StopRemoteService();

--- a/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditor.cs
+++ b/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditor.cs
@@ -142,7 +142,7 @@ namespace UnityARInterface
                 message = string.Format("Connected to remote AR device: {0}", m_RemoteInterface.playerId);
                 var buttonRect = new Rect((Screen.width / 2) - 200, (Screen.height / 2) - 200, 400, 100);
 
-                if (m_RemoteInterface.IsRunning)
+                if (m_RemoteInterface.IsRemoteServiceRunning)
                 {
                     if (GUI.Button(buttonRect, "Stop Remote AR Session"))
                         m_RemoteInterface.StopRemoteService();

--- a/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
+++ b/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
@@ -100,7 +100,8 @@ namespace UnityARInterface
 
         public void ScreenCaptureUVMessageHandler(MessageEventArgs message)
         {
-            if (m_RemoteScreenUVTexture == null)
+            //In case of ARCore sending grayscale image, UV data would be null.
+            if (m_RemoteScreenUVTexture == null || message.data == null)
                 return;
 
             m_RemoteScreenUVTexture.LoadRawTextureData(message.data);

--- a/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
+++ b/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
@@ -2,6 +2,7 @@
 using UnityEngine;
 using UnityEngine.Networking.PlayerConnection;
 using Utils;
+using System.Collections;
 
 #if UNITY_EDITOR
 using UnityEditor.Networking.PlayerConnection;
@@ -39,7 +40,7 @@ namespace UnityARInterface
         public int playerId { get { return m_CurrentPlayerId; } }
 
         private bool m_ServiceRunning = false;
-        public bool serviceRunning { get { return m_ServiceRunning; } }
+        public override bool IsRunning { get { return m_ServiceRunning; } }
 
         Texture2D m_RemoteScreenYTexture;
         Texture2D m_RemoteScreenUVTexture;
@@ -183,14 +184,15 @@ namespace UnityARInterface
         //
         // From the ARInterface
         //
-        public override bool StartService(Settings settings)
+        public override IEnumerator StartService(Settings settings)
         {
-            return true;
+            IsRunning = true;
+            return null;
         }
 
         public override void StopService()
         {
-
+            IsRunning = false;
         }
 
         public override void SetupCamera(Camera camera)

--- a/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
+++ b/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
@@ -39,6 +39,8 @@ namespace UnityARInterface
         public bool connected { get { return m_CurrentPlayerId != -1; } }
         public int playerId { get { return m_CurrentPlayerId; } }
 
+        public bool IsRemoteServiceRunning { get; protected set; } 
+
         Texture2D m_RemoteScreenYTexture;
         Texture2D m_RemoteScreenUVTexture;
 
@@ -169,13 +171,13 @@ namespace UnityARInterface
             sendVideo = m_SendVideo;
             var serializedSettings = (SerializableARSettings)settings;
             SendToPlayer(ARMessageIds.SubMessageIds.startService, serializedSettings);
-            IsRunning = true;
+            IsRemoteServiceRunning = true;
         }
 
         public void StopRemoteService()
         {
             SendToPlayer(ARMessageIds.SubMessageIds.stopService, null);
-            IsRunning = false;
+            IsRemoteServiceRunning = false;
         }
 
         //

--- a/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
+++ b/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
@@ -39,9 +39,6 @@ namespace UnityARInterface
         public bool connected { get { return m_CurrentPlayerId != -1; } }
         public int playerId { get { return m_CurrentPlayerId; } }
 
-        private bool m_ServiceRunning = false;
-        public override bool IsRunning { get { return m_ServiceRunning; } }
-
         Texture2D m_RemoteScreenYTexture;
         Texture2D m_RemoteScreenUVTexture;
 
@@ -172,13 +169,13 @@ namespace UnityARInterface
             sendVideo = m_SendVideo;
             var serializedSettings = (SerializableARSettings)settings;
             SendToPlayer(ARMessageIds.SubMessageIds.startService, serializedSettings);
-            m_ServiceRunning = true;
+            IsRunning = true;
         }
 
         public void StopRemoteService()
         {
             SendToPlayer(ARMessageIds.SubMessageIds.stopService, null);
-            m_ServiceRunning = false;
+            IsRunning = false;
         }
 
         //

--- a/Assets/UnityARInterface/Scripts/ARController.cs
+++ b/Assets/UnityARInterface/Scripts/ARController.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System.Collections;
 
 #if UNITY_EDITOR
 using UnityEngine.Networking.PlayerConnection;
@@ -65,7 +66,15 @@ namespace UnityARInterface
             }
         }
 
-        public bool serviceRunning { get; protected set; }
+        public bool IsRunning
+        {
+            get
+            {
+                if (m_ARInterface == null)
+                    return false;
+                return m_ARInterface.IsRunning;
+            }
+        }
 
         public void AlignWithPointOfInterest(Vector3 position)
         {
@@ -114,9 +123,15 @@ namespace UnityARInterface
             if (m_ARCamera == null)
                 m_ARCamera = Camera.main;
 
-            serviceRunning = m_ARInterface.StartService(GetSettings());
+            StopAllCoroutines();
+            StartCoroutine(StartServiceRoutine());
 
-            if (serviceRunning)
+        }
+
+        IEnumerator StartServiceRoutine()
+        {
+            yield return m_ARInterface.StartService(GetSettings());
+            if (IsRunning)
             {
                 m_ARInterface.SetupCamera(m_ARCamera);
                 Application.onBeforeRender += OnBeforeRender;
@@ -127,9 +142,11 @@ namespace UnityARInterface
             }
         }
 
+
         void OnDisable()
         {
-            if (serviceRunning)
+            StopAllCoroutines();
+            if (IsRunning)
             {
                 m_ARInterface.StopService();
                 Application.onBeforeRender -= OnBeforeRender;

--- a/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
@@ -10,8 +10,6 @@ namespace UnityARInterface
     public class ARCoreInterface : ARInterface
     {
         private List<TrackedPlane> m_TrackedPlaneBuffer = new List<TrackedPlane>();
-        private float? m_HorizontalFov;
-        private float? m_VerticalFov;
         private ScreenOrientation m_CachedScreenOrientation;
         private Dictionary<TrackedPlane, BoundedPlane> m_TrackedPlanes = new Dictionary<TrackedPlane, BoundedPlane>();
         private SessionManager m_SessionManager;

--- a/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
@@ -178,6 +178,9 @@ namespace UnityARInterface
 
         public override bool TryGetPointCloud(ref PointCloud pointCloud)
         {
+            if (Frame.TrackingState != TrackingState.Tracking)
+                return false;
+
             // Fill in the data to draw the point cloud.
             m_TempPointCloud.Clear();
             Frame.PointCloud.CopyPoints(m_TempPointCloud);
@@ -197,7 +200,7 @@ namespace UnityARInterface
 
         public override LightEstimate GetLightEstimate()
         {
-            if (Session.ConnectionState == SessionConnectionState.Connected)
+            if (Session.ConnectionState == SessionConnectionState.Connected && Frame.LightEstimate.State == LightEstimateState.Valid)
             {
                 return new LightEstimate()
                 {
@@ -275,6 +278,13 @@ namespace UnityARInterface
 
         public override void Update()
         {
+            if (m_SessionManager == null)
+            {
+                return;
+            }
+
+            AsyncTask.OnUpdate();
+
             if (Frame.TrackingState != TrackingState.Tracking)
                 return;
 

--- a/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
@@ -18,6 +18,20 @@ namespace UnityARInterface
         private Matrix4x4 m_DisplayTransform = Matrix4x4.identity;
         private List<Vector4> m_TempPointCloud = new List<Vector4>();
 
+        public override bool IsSupported
+        {
+            get
+            {
+                if (m_SessionManager == null)
+                    m_SessionManager = SessionManager.CreateSession();
+
+                if (m_ARCoreSessionConfig == null)
+                    m_ARCoreSessionConfig = ScriptableObject.CreateInstance<ARCoreSessionConfig>();
+
+                return m_SessionManager.CheckSupported((m_ARCoreSessionConfig));
+            }
+        }
+
         public override IEnumerator StartService(Settings settings)
         {
             if (m_ARCoreSessionConfig == null)
@@ -33,7 +47,7 @@ namespace UnityARInterface
             if (m_SessionManager == null)
             {
                 m_SessionManager = SessionManager.CreateSession();
-                if (!m_SessionManager.CheckSupported((m_ARCoreSessionConfig))){
+                if (!IsSupported){
                     ARDebug.LogError("The requested ARCore session configuration is not supported.");
                     yield break;
                 }

--- a/Assets/UnityARInterface/Scripts/AREditorInterface.cs
+++ b/Assets/UnityARInterface/Scripts/AREditorInterface.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -24,7 +25,7 @@ namespace UnityARInterface
         Vector3 m_EulerAngles;
         Vector3[] m_PointCloud;
 
-        public override bool StartService(Settings settings)
+        public override IEnumerator StartService(Settings settings)
         {
             m_CameraPose = Pose.identity;
             m_CameraPose.position.Set(0, 0, 0);
@@ -58,12 +59,13 @@ namespace UnityARInterface
                     UnityEngine.Random.Range(-2f, 2f));
             }
 
-            return true;
+            IsRunning = true;
+            return null;
         }
 
         public override void StopService()
         {
-
+            IsRunning = false;
         }
 
         public override bool TryGetUnscaledPose(ref Pose pose)

--- a/Assets/UnityARInterface/Scripts/ARInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARInterface.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -45,7 +46,9 @@ namespace UnityARInterface
         public static Action<BoundedPlane> planeUpdated;
         public static Action<BoundedPlane> planeRemoved;
 
-        public abstract bool StartService(Settings settings);
+        public virtual bool IsRunning { get; protected set; } 
+
+        public abstract IEnumerator StartService(Settings settings);
 
         public abstract void StopService();
 

--- a/Assets/UnityARInterface/Scripts/ARInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARInterface.cs
@@ -48,6 +48,8 @@ namespace UnityARInterface
 
         public virtual bool IsRunning { get; protected set; } 
 
+        public virtual bool IsSupported { get { return true; } }
+
         public abstract IEnumerator StartService(Settings settings);
 
         public abstract void StopService();

--- a/Assets/UnityARInterface/Scripts/ARKitInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARKitInterface.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using UnityEngine;
@@ -27,7 +28,7 @@ namespace UnityARInterface
 		private Matrix4x4 m_DisplayTransform;
 
         // Use this for initialization
-        public override bool StartService(Settings settings)
+        public override IEnumerator StartService(Settings settings)
         {
             ARKitWorldTrackingSessionConfiguration sessionConfig = new ARKitWorldTrackingSessionConfiguration(
                 UnityARAlignment.UnityARAlignmentGravity,
@@ -48,7 +49,9 @@ namespace UnityARInterface
             UnityARSessionNativeInterface.ARAnchorRemovedEvent += RemoveAnchor;
             UnityARSessionNativeInterface.ARFrameUpdatedEvent += UpdateFrame;
 
-            return true;
+            IsRunning = true;
+
+            return null;
         }
 
         private Vector3 GetWorldPosition(ARPlaneAnchor arPlaneAnchor)
@@ -140,7 +143,6 @@ namespace UnityARInterface
             OnPlaneUpdated(GetBoundedPlane(arPlaneAnchor));
         }
 
-        // Update is called once per frame
         public override void StopService()
         {
             UnityARSessionNativeInterface.GetARSessionNativeInterface().Pause();
@@ -149,6 +151,8 @@ namespace UnityARInterface
             m_PinnedYArray.Free();
             m_PinnedUVArray.Free();
             m_TexturesInitialized = false;
+
+            IsRunning = false;
         }
 
         public override bool TryGetUnscaledPose(ref Pose pose)

--- a/Assets/UnityARInterface/Scripts/ARKitInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARKitInterface.cs
@@ -26,22 +26,37 @@ namespace UnityARInterface
         private Vector3[] m_PointCloudData;
         private LightEstimate m_LightEstimate;
 		private Matrix4x4 m_DisplayTransform;
+        private ARKitWorldTrackingSessionConfiguration m_SessionConfig;
+
+        public override bool IsSupported
+        {
+            get
+            {
+                return m_SessionConfig.IsSupported;
+            }
+        }
 
         // Use this for initialization
         public override IEnumerator StartService(Settings settings)
         {
-            ARKitWorldTrackingSessionConfiguration sessionConfig = new ARKitWorldTrackingSessionConfiguration(
+            m_SessionConfig = new ARKitWorldTrackingSessionConfiguration(
                 UnityARAlignment.UnityARAlignmentGravity,
                 settings.enablePlaneDetection ? UnityARPlaneDetection.Horizontal : UnityARPlaneDetection.None,
                 settings.enablePointCloud,
                 settings.enableLightEstimation);
+
+            if (!IsSupported)
+            {
+                Debug.LogError("The requested ARKit session configuration is not supported");
+                return null;
+            }
 
             UnityARSessionRunOption runOptions =
                 UnityARSessionRunOption.ARSessionRunOptionRemoveExistingAnchors |
                 UnityARSessionRunOption.ARSessionRunOptionResetTracking;
 
             nativeInterface.RunWithConfigAndOptions(
-                sessionConfig, runOptions);
+                m_SessionConfig, runOptions);
 
             // Register for plane detection
             UnityARSessionNativeInterface.ARAnchorAddedEvent += AddAnchor;

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ To take a look at the API, examine `ARInterface.cs` in the project. Here follows
 
 Firstly we have the calls to start and stop the AR session:
 
-       public abstract bool StartService(Settings settings);
+       public abstract IEnumerator StartService(Settings settings);
        public abstract void StopService();
 
 The `Settings` parameter lets you choose to enable any one or more of point cloud creation, light estimation and plane detection in the session.


### PR DESCRIPTION
This PR introduces few improvements:

- [x] 1. Asynchronous `StartService`
- [x] 2. `IsRunning` property
- [x] 3. `IsSupported` property
- [x] 4. Fix `TryGetCameraImage` for ARCore

1. Old interface had `bool StartService(Settings settings)` a synchronous function to start the service, which didn't work well since starting the camera and asking for permission is an asynchronous operation. Was replaced in in favour of `IEnumerator StartService(Settings settings)` which can be ran as a Coroutine. For interfaces that returned immediately, this function returns an IEnumerator that returns immediately as well.

This interface change does not break any existing projects, since the application logic mostly doesn't talk to the `ARInterface`, but to the `ARController`.

2. The old interface returned a boolean indicating the success of the session connection. For this purpose, a `bool IsRunning` property was introduced to the `ARInterface` and all classes that implement it, and the implementation is responsible of setting this property to true whenever the connection is a success. In addition, the `serviceRunning` Property in the `ARController` class and the 'm_ServiceRunning' field in the `ARRemoteDevice` were renamed for consistency.

In addition, **some changes** were made to the `ARCoreInterface` with additional checks for the validity of the session, asking for camera permission, and creating a session without an additional game object for the session.
