### PR TITLE
Anchor support

### DIFF
--- a/Assets/UnityARInterface/Scripts/ARAnchor.cs
+++ b/Assets/UnityARInterface/Scripts/ARAnchor.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace UnityARInterface
+{
+    public class ARAnchor : ARBase
+    {
+        [HideInInspector]
+        public string anchorID;
+
+        private ARInterface m_ARInterface;
+
+        private void Awake()
+        {
+            m_ARInterface = ARInterface.GetInterface();
+            if (m_ARInterface == null)
+                Destroy(this);
+        }
+
+        void Start()
+        {
+            UpdateAnchor();
+        }
+
+        public void UpdateAnchor()
+        {
+            m_ARInterface.DestroyAnchor(this);
+            m_ARInterface.ApplyAnchor(this);
+        }
+
+        private void OnDestroy()
+        {
+            if (m_ARInterface != null && !string.IsNullOrEmpty(anchorID))
+            {
+                m_ARInterface.DestroyAnchor(this);
+            }
+        }
+
+    }
+}

--- a/Assets/UnityARInterface/Scripts/ARAnchor.cs.meta
+++ b/Assets/UnityARInterface/Scripts/ARAnchor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fb52f11595a74c1ca6ad8025865fdb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
@@ -483,7 +483,7 @@ namespace UnityARInterface
             //Since ARCore wants to create it's own GameObject, we can keep a reference to it and copy its Pose.
             //Not the best, but probably will change when ARCore releases.
             Anchor arCoreAnchor = Session.CreateWorldAnchor(new Pose(arAnchor.transform.position, arAnchor.transform.rotation));
-            arAnchor.anchorID = arCoreAnchor.gameObject.GetInstanceID().ToString();
+            arAnchor.anchorID = Guid.NewGuid().ToString();
             m_Anchors[arAnchor] = arCoreAnchor;
         }
 

--- a/Assets/UnityARInterface/Scripts/ARInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARInterface.cs
@@ -95,6 +95,14 @@ namespace UnityARInterface
                 planeRemoved(plane);
         }
 
+        public virtual void ApplyAnchor(ARAnchor arAnchor)
+        {
+        }
+
+        public virtual void DestroyAnchor(ARAnchor arAnchor)
+        {
+        }
+
         private static ARInterface m_Interface;
 
         public static ARInterface GetInterface()

--- a/Assets/UnityARInterface/Scripts/ARKitInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARKitInterface.cs
@@ -27,6 +27,7 @@ namespace UnityARInterface
         private LightEstimate m_LightEstimate;
 		private Matrix4x4 m_DisplayTransform;
         private ARKitWorldTrackingSessionConfiguration m_SessionConfig;
+        private Dictionary<string, ARAnchor> m_Anchors = new Dictionary<string, ARAnchor>();
 
         public override bool IsSupported
         {
@@ -63,6 +64,7 @@ namespace UnityARInterface
             UnityARSessionNativeInterface.ARAnchorUpdatedEvent += UpdateAnchor;
             UnityARSessionNativeInterface.ARAnchorRemovedEvent += RemoveAnchor;
             UnityARSessionNativeInterface.ARFrameUpdatedEvent += UpdateFrame;
+            UnityARSessionNativeInterface.ARUserAnchorUpdatedEvent += UpdateUserAnchor;
 
             IsRunning = true;
 
@@ -158,8 +160,24 @@ namespace UnityARInterface
             OnPlaneUpdated(GetBoundedPlane(arPlaneAnchor));
         }
 
+        private void UpdateUserAnchor(ARUserAnchor anchorData)
+        {
+            ARAnchor anchor;
+            if(m_Anchors.TryGetValue(anchorData.identifier, out anchor)){
+                anchor.transform.position = anchorData.transform.GetColumn(3);
+                anchor.transform.rotation = anchorData.transform.rotation;   
+            }
+        }
+
+
         public override void StopService()
         {
+            var anchors = m_Anchors.Values;
+            foreach (var anchor in anchors)
+            {
+                DestroyAnchor(anchor);
+            }
+            UnityARSessionNativeInterface.ARUserAnchorUpdatedEvent -= UpdateUserAnchor;
             UnityARSessionNativeInterface.GetARSessionNativeInterface().Pause();
 
             nativeInterface.SetCapturePixelData(false, IntPtr.Zero, IntPtr.Zero);
@@ -253,6 +271,35 @@ namespace UnityARInterface
         public override void Update()
         {
 
+        }
+
+        public override void ApplyAnchor(ARAnchor arAnchor)
+        {
+            if (!IsRunning)
+                return;
+            
+            Matrix4x4 matrix = Matrix4x4.TRS(arAnchor.transform.position, arAnchor.transform.rotation, arAnchor.transform.localScale);
+            UnityARUserAnchorData anchorData = new UnityARUserAnchorData();
+            anchorData.transform.column0 = matrix.GetColumn(0);
+            anchorData.transform.column1 = matrix.GetColumn(1);
+            anchorData.transform.column2 = matrix.GetColumn(2);
+            anchorData.transform.column3 = matrix.GetColumn(3);
+
+            anchorData = UnityARSessionNativeInterface.GetARSessionNativeInterface().AddUserAnchor(anchorData);
+            arAnchor.anchorID = anchorData.identifierStr;
+            m_Anchors[arAnchor.anchorID] = arAnchor;
+        }
+
+        public override void DestroyAnchor(ARAnchor arAnchor)
+        {
+            if(!string.IsNullOrEmpty(arAnchor.anchorID)){
+                UnityARSessionNativeInterface.GetARSessionNativeInterface().RemoveUserAnchor(arAnchor.anchorID);
+                if (m_Anchors.ContainsKey(arAnchor.anchorID))
+                {
+                    m_Anchors.Remove(arAnchor.anchorID);
+                }
+                arAnchor.anchorID = null;
+            }
         }
     }
 }


### PR DESCRIPTION
Added support for Anchors, that allows anchoring certain game objects to real world positions, in case of a shifting in tracking, while the SDKs adjust their understanding of the world.

Usage:
Simply place a game object where it is supposed to be locked, and add a `UnityARInterface.ARAnchor` to it. Both SDKs recommand removing unused anchors since they are expensive if too many. To do so, simply destroy the ARAnchor.

In case we want to Re-anchor an object, we simply move it to a new location, and call `UpdateAnchor` (which would destroy the old native anchor, and create a new one)

On the interface itself, there are `ApplyAnchor` and `DestroyAnchor` functions, that take a `ARAnchor` component, and anchor it, or remove the anchoring from it.

Internally, it's using `UnityARUserAnchorData` on ARKit, and `Anchor` (which is based on `TrackedPoint` really) on ARCore.

Doesn't do much on the editor. Not added for Remote, since it only serves as an improvement for tracking on device, but doesn't really add functionality.

_tl;dr_

- Use `AddComponent<ARAnchor>()` to lock it in place
- Use `arAnchor.UpdateAnchor()` to change the anchoring (after moving the `gameObject` to a new location)
- Use `Destroy(arAnchor)` to remove the anchor

Will update README if this is to be merged.