### PR TITLE
FIX scene restart (issue #30)

### DIFF
--- a/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
@@ -210,6 +210,7 @@ namespace UnityARInterface
             Session.Destroy();
             TextureReader_destroy();
             IsRunning = false;
+            m_SessionManager = null;
         }
 
         public override bool TryGetUnscaledPose(ref Pose pose)


### PR DESCRIPTION
Resets `m_SessionManager` as the next time the code would run (scene gets reopened) it would use this old reference while a new session manager was already created and should be used instead.