### PR TITLE
Toggling anchors, fix line ending

### DIFF
--- a/Assets/UnityARInterface/Scripts/ARAnchor.cs
+++ b/Assets/UnityARInterface/Scripts/ARAnchor.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace UnityARInterface
 {
@@ -11,6 +8,7 @@ namespace UnityARInterface
         public string anchorID;
 
         private ARInterface m_ARInterface;
+        private bool started;
 
         private void Awake()
         {
@@ -22,20 +20,29 @@ namespace UnityARInterface
         void Start()
         {
             UpdateAnchor();
+            started = true;
+        }
+
+        private void OnEnable()
+        {
+            if (started)
+                UpdateAnchor();
+        }
+
+        private void OnDisable()
+        {
+            m_ARInterface.DestroyAnchor(this);
+        }
+
+        private void OnDestroy()
+        {
+            m_ARInterface.DestroyAnchor(this);
         }
 
         public void UpdateAnchor()
         {
             m_ARInterface.DestroyAnchor(this);
             m_ARInterface.ApplyAnchor(this);
-        }
-
-        private void OnDestroy()
-        {
-            if (m_ARInterface != null && !string.IsNullOrEmpty(anchorID))
-            {
-                m_ARInterface.DestroyAnchor(this);
-            }
         }
 
     }


### PR DESCRIPTION
Creating an anchor is done by adding the `ARAnchor` component, but disabling it temporarily is not practical, because you need to destroy the component, and add another one.

One common use case is to change the anchor of an interactive object in the scene with drag and drop, raycast, etc. So I would have an anchor on my object, and when I start dragging it, I disable the anchor, and re-enable it again when I drop it.

Also, this would allow to have the Anchor already on the game object disabled, or adding it disabled as well (e.g `gameObject.AddComponent<ARAnchor>().enabled = false;`)
With this approach, the native anchor will be created only when the `ARAnchor` component gets enabled. 