### PR TITLE
Fix for #42 ARCore BuildHelper.cs compiling on Unity 2018

### DIFF
--- a/Assets/GoogleARCore/SDK/Scripts/Editor/BuildHelper.cs
+++ b/Assets/GoogleARCore/SDK/Scripts/Editor/BuildHelper.cs
@@ -23,14 +23,17 @@ namespace GoogleARCoreInternal
     using System.Diagnostics.CodeAnalysis;
     using UnityEditor;
     using UnityEditor.Build;
+#if UNITY_2018_1_OR_NEWER
+    using UnityEditor.Build.Reporting;
+#endif
     using UnityEngine;
 
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented",
-     Justification = "Internal")]
+    Justification = "Internal")]
     public class BuildHelper : IPreprocessBuild
     {
         [SuppressMessage("UnityRules.UnityStyleRules", "US1000:FieldsMustBeUpperCamelCase",
-         Justification = "Overriden property.")]
+        Justification = "Overriden property.")]
         public int callbackOrder
         {
             get
@@ -39,8 +42,13 @@ namespace GoogleARCoreInternal
             }
         }
 
+#if UNITY_2018_1_OR_NEWER
+        public void OnPreprocessBuild(BuildReport report)
+        {
+#else
         public void OnPreprocessBuild(BuildTarget target, string path)
         {
+#endif 
             var isARCoreRequired = ARCoreProjectSettings.Instance.IsARCoreRequired;
 
             Debug.LogFormat("Building application with {0} ARCore support.",

--- a/Assets/GoogleARCore/SDK/Scripts/Editor/BuildHelper.cs
+++ b/Assets/GoogleARCore/SDK/Scripts/Editor/BuildHelper.cs
@@ -29,11 +29,11 @@ namespace GoogleARCoreInternal
     using UnityEngine;
 
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:ElementsMustBeDocumented",
-    Justification = "Internal")]
+     Justification = "Internal")]
     public class BuildHelper : IPreprocessBuild
     {
         [SuppressMessage("UnityRules.UnityStyleRules", "US1000:FieldsMustBeUpperCamelCase",
-        Justification = "Overriden property.")]
+         Justification = "Overriden property.")]
         public int callbackOrder
         {
             get


### PR DESCRIPTION
The interface `IPreprocessBuild` used in `GoogleARCore/SDK/Scripts/Editor/BuildHelper.cs` has changed for Unity 2018. This fixes that.