### PR TITLE
Hotfix for ARKit background rendering

### DIFF
--- a/Assets/UnityARInterface/Scripts/ARInterfaceBackgroundRenderer.cs
+++ b/Assets/UnityARInterface/Scripts/ARInterfaceBackgroundRenderer.cs
@@ -3,20 +3,33 @@ using UnityEngine.XR;
 
 namespace UnityARInterface
 {
+    /// <summary>
+    /// AR Interface background renderer.
+    /// </summary>
     public class ARInterfaceBackgroundRenderer : ARBackgroundRenderer
     {
         public bool Enabled { get; protected set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:UnityARInterface.ARInterfaceBackgroundRenderer"/> class.
+        /// </summary>
         public ARInterfaceBackgroundRenderer()
         {
             Enabled = true;
         }
 
+        /// <summary>
+        /// Enables the rendering.
+        /// </summary>
+        /// <returns><c>true</c>, if rendering was enabled, <c>false</c> otherwise.</returns>
         public bool EnableRendering()
         {
             return Enabled = EnableARBackgroundRendering();
         }
 
+        /// <summary>
+        /// Disables the rendering and sets camera to draw black solid color
+        /// </summary>
         public void DisableRendering()
         {
             m_Camera.clearFlags = CameraClearFlags.SolidColor;

--- a/Assets/UnityARInterface/Scripts/ARInterfaceBackgroundRenderer.cs
+++ b/Assets/UnityARInterface/Scripts/ARInterfaceBackgroundRenderer.cs
@@ -1,0 +1,30 @@
+﻿using UnityEngine;
+using UnityEngine.XR;
+
+namespace UnityARInterface
+{
+    public class ARInterfaceBackgroundRenderer : ARBackgroundRenderer
+    {
+        public bool Enabled { get; protected set; }
+
+        public ARInterfaceBackgroundRenderer()
+        {
+            Enabled = true;
+        }
+
+        public bool EnableRendering()
+        {
+            return Enabled = EnableARBackgroundRendering();
+        }
+
+        public void DisableRendering()
+        {
+            m_Camera.clearFlags = CameraClearFlags.SolidColor;
+            m_Camera.backgroundColor = Color.black;
+
+            DisableARBackgroundRendering();
+        
+            Enabled = false;
+        }
+    }
+}

--- a/Assets/UnityARInterface/Scripts/ARInterfaceBackgroundRenderer.cs.meta
+++ b/Assets/UnityARInterface/Scripts/ARInterfaceBackgroundRenderer.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: fa5d2cedb20d2487596b55608d7835bc
+timeCreated: 1519832374
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UnityARInterface/Scripts/ARKitInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARKitInterface.cs
@@ -23,7 +23,7 @@ namespace UnityARInterface
         private byte[] m_TextureUVBytes;
         private byte[] m_TextureYBytes2;
         private byte[] m_TextureUVBytes2;
-        private ARBackgroundRenderer m_BackgroundRenderer;
+        private ARInterfaceBackgroundRenderer m_BackgroundRenderer;
         private Texture2D _videoTextureY;
         private Texture2D _videoTextureCbCr;
         private GCHandle m_PinnedYArray;
@@ -281,7 +281,7 @@ namespace UnityARInterface
             m_Camera = camera;
             m_ClearMaterial = Resources.Load("YUVMaterial", typeof(Material)) as Material;
 
-            m_BackgroundRenderer = new ARBackgroundRenderer();
+            m_BackgroundRenderer = new ARInterfaceBackgroundRenderer();
             m_BackgroundRenderer.backgroundMaterial = m_ClearMaterial;
             m_BackgroundRenderer.camera = camera;
         }
@@ -296,7 +296,13 @@ namespace UnityARInterface
             ARTextureHandles handles = UnityARSessionNativeInterface.GetARSessionNativeInterface().GetARVideoTextureHandles();
             if (handles.textureY == System.IntPtr.Zero || handles.textureCbCr == System.IntPtr.Zero)
             {
+                m_BackgroundRenderer.DisableRendering();
                 return;
+            }
+
+            if(!m_BackgroundRenderer.Enabled)
+            {
+                m_BackgroundRenderer.EnableRendering();
             }
 
             Resolution currentResolution = Screen.currentResolution;


### PR DESCRIPTION
Hotfix for iOS green screen flash (#45).

- [x] Tested on iPhone 6s.

This issue (#45) needs more work (better command buffer management, I think), but this hotfix eliminate "color shock/flash", and just looks good (can't see any difference between other frameworks).
Fixed by drawing black solid color instead of empty (green) 'YUVMaterial'.

