### PR TITLE
Fix arcore remote backgroundrendering

### DIFF
--- a/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
+++ b/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
@@ -209,6 +209,7 @@ namespace UnityARInterface
         public void StartRemoteService(Settings settings)
         {
             sendVideo = m_SendVideo;
+            BackgroundRendering = m_BackgroundRendering;
             var serializedSettings = (SerializableARSettings)settings;
             SendToPlayer(ARMessageIds.SubMessageIds.startService, serializedSettings);
             IsRemoteServiceRunning = true;

--- a/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
@@ -48,11 +48,10 @@ namespace UnityARInterface
         private Dictionary<TrackedPlane, BoundedPlane> m_TrackedPlanes = new Dictionary<TrackedPlane, BoundedPlane>();
         private ARCoreSession m_ARCoreSession;
         private ARCoreSessionConfig m_ARCoreSessionConfig;
-        private ARBackgroundRenderer m_BackgroundRenderer;
+        private ARCoreBackgroundRenderer m_ARCoreBackgroundRenderer;
         private Matrix4x4 m_DisplayTransform = Matrix4x4.identity;
         private List<Vector4> m_TempPointCloud = new List<Vector4>();
         private Dictionary<ARAnchor, Anchor> m_Anchors = new Dictionary<ARAnchor, Anchor>();
-        private bool m_BackgroundRendering;
 
         public override bool IsSupported
         {
@@ -68,16 +67,17 @@ namespace UnityARInterface
         {
             get
             {
-                return m_BackgroundRendering;
+                if (m_ARCoreBackgroundRenderer == null)
+                    return false;
+
+                return m_ARCoreBackgroundRenderer.enabled;
             }
             set
             {
-                if (m_BackgroundRenderer == null)
+                if (m_ARCoreBackgroundRenderer == null)
                     return;
 
-                m_BackgroundRendering = value;
-                m_BackgroundRenderer.mode = m_BackgroundRendering ? 
-                    ARRenderMode.MaterialAsBackground : ARRenderMode.StandardBackground;
+                m_ARCoreBackgroundRenderer.enabled = value;
             }
         }
 
@@ -163,9 +163,6 @@ namespace UnityARInterface
             m_ARCoreSession.enabled = false;
             TextureReader_destroy();
             BackgroundRendering = false;
-            m_BackgroundRenderer.backgroundMaterial = null;
-            m_BackgroundRenderer.camera = null;
-            m_BackgroundRenderer = null;
             IsRunning = false;
         }
 
@@ -337,14 +334,13 @@ namespace UnityARInterface
 
         public override void SetupCamera(Camera camera)
         {
-            ARCoreBackgroundRenderer backgroundRenderer =
-                camera.GetComponent<ARCoreBackgroundRenderer>();
+            m_ARCoreBackgroundRenderer = camera.GetComponent<ARCoreBackgroundRenderer>();
 
-            if (backgroundRenderer == null)
+            if (m_ARCoreBackgroundRenderer == null)
             {
                 camera.gameObject.SetActive(false);
-                backgroundRenderer = camera.gameObject.AddComponent<ARCoreBackgroundRenderer>();
-                backgroundRenderer.BackgroundMaterial = Resources.Load("Materials/ARBackground", typeof(Material)) as Material;
+                m_ARCoreBackgroundRenderer = camera.gameObject.AddComponent<ARCoreBackgroundRenderer>();
+                m_ARCoreBackgroundRenderer.BackgroundMaterial = Resources.Load("Materials/ARBackground", typeof(Material)) as Material;
                 camera.gameObject.SetActive(true);
             }
         }


### PR DESCRIPTION
For the `ARCoreInterface`, the logic to enable background rendering on the remote device was tied to the use of the `ARBackgroundRenderer`, which we no longer use. This bases the logic on the `enabled` status of the `ARCoreBackgroundRenderer`.

I also added a call to set the state of the `BackgroundRendering` in the `ARRemoteEditorInterface` which triggers a `SendToPlayer` call to enable background rendering on the remote device.