### PR TITLE
Fix for Editor Interface exception if service isn't running

### DIFF
--- a/Assets/UnityARInterface/Scripts/AREditorInterface.cs
+++ b/Assets/UnityARInterface/Scripts/AREditorInterface.cs
@@ -86,8 +86,8 @@ namespace UnityARInterface
 
         public override bool TryGetPointCloud(ref PointCloud pointCloud)
         {
-			if (!IsRunning)
-				return false;
+            if (!IsRunning)
+			    return false;
 
             if (pointCloud.points == null)
                 pointCloud.points = new List<Vector3>();

--- a/Assets/UnityARInterface/Scripts/AREditorInterface.cs
+++ b/Assets/UnityARInterface/Scripts/AREditorInterface.cs
@@ -86,6 +86,9 @@ namespace UnityARInterface
 
         public override bool TryGetPointCloud(ref PointCloud pointCloud)
         {
+			if (!IsRunning)
+				return false;
+
             if (pointCloud.points == null)
                 pointCloud.points = new List<Vector3>();
 


### PR DESCRIPTION
If ARPointCloudVisualizer is enabled but the service isn't running on startup, exceptions are thrown when trying to use AddRange for the null point list. Based on other platform interfaces, I added a check to see if the service was running for an early exit.