### PR TITLE
Universal HitTest

### DIFF
--- a/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
+++ b/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
@@ -311,6 +311,11 @@ namespace UnityARInterface
                 }
             }
         }
+
+        public override bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        {
+            throw new System.NotImplementedException();
+        }
     }
 }
 #endif

--- a/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
+++ b/Assets/UnityARInterface/ARRemote/Scripts/ARRemoteEditorInterface.cs
@@ -312,7 +312,7 @@ namespace UnityARInterface
             }
         }
 
-        public override bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        public override bool NativeHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
         {
             throw new System.NotImplementedException();
         }

--- a/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
@@ -463,5 +463,42 @@ namespace UnityARInterface
 
             }
         }
+
+        public TrackableHitFlags GetTrackableHitFlags(List<HitTestResultType> hitTypes){
+            TrackableHitFlags nativeFlags = TrackableHitFlags.None; 
+            foreach(HitTestResultType flag in hitTypes){
+                switch(flag){
+                    case HitTestResultType.FeaturePoint:
+                        nativeFlags |= TrackableHitFlags.FeaturePoint;
+                        break;
+                    case HitTestResultType.PlaneWithinExtents:
+                        nativeFlags |= TrackableHitFlags.PlaneWithinBounds;
+                        break;
+                    case HitTestResultType.PlaneWithinInfinity:
+                        nativeFlags |= TrackableHitFlags.PlaneWithinInfinity;
+                        break;
+                }
+            }
+            return nativeFlags;
+        } 
+
+        public override bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        {
+            List<TrackableHit> hits = new List<TrackableHit>();
+            TrackableHitFlags raycastFilter = GetTrackableHitFlags(hitTestResultTypes);
+            hitTestResult = null;
+
+            TrackableHit hit;
+            if (Frame.Raycast(screenPos.x, screenPos.y, raycastFilter, out hit))
+            {
+                hitTestResult = new HitTestResult
+                {
+                    position = hit.Pose.position,
+                    rotation = hit.Pose.rotation
+                };
+                return true;
+            }
+            return false;
+        }
     }
 }

--- a/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARCoreInterface.cs
@@ -471,7 +471,7 @@ namespace UnityARInterface
                     case HitTestResultType.FeaturePoint:
                         nativeFlags |= TrackableHitFlags.FeaturePoint;
                         break;
-                    case HitTestResultType.PlaneWithinExtents:
+                    case HitTestResultType.PlaneWithinBoxExtents:
                         nativeFlags |= TrackableHitFlags.PlaneWithinBounds;
                         break;
                     case HitTestResultType.PlaneWithinInfinity:
@@ -482,7 +482,7 @@ namespace UnityARInterface
             return nativeFlags;
         } 
 
-        public override bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        public override bool NativeHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
         {
             List<TrackableHit> hits = new List<TrackableHit>();
             TrackableHitFlags raycastFilter = GetTrackableHitFlags(hitTestResultTypes);

--- a/Assets/UnityARInterface/Scripts/AREditorInterface.cs
+++ b/Assets/UnityARInterface/Scripts/AREditorInterface.cs
@@ -182,13 +182,19 @@ namespace UnityARInterface
             }
         }
 
-        public override bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        public override bool NativeHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
         {
-            
+            hitTestResult = null;
+
+            if (ARPlaneVisualizer.instance == null)
+            {
+                Debug.LogWarning("HitTest needs ARPlaneVisualizer in the current scene");
+                return false;
+            }
+
             Ray ray = Camera.main.ScreenPointToRay(screenPos);
             RaycastHit hit;
-            hitTestResult = null;
-            if(Physics.Raycast(ray, out hit)){
+            if(Physics.Raycast(ray, out hit, ARPlaneVisualizer.instance.m_PlaneLayer )){
                 hitTestResult = new HitTestResult()
                 {
                     position = hit.point,

--- a/Assets/UnityARInterface/Scripts/AREditorInterface.cs
+++ b/Assets/UnityARInterface/Scripts/AREditorInterface.cs
@@ -181,5 +181,24 @@ namespace UnityARInterface
                     break;
             }
         }
+
+        public override bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        {
+            
+            Ray ray = Camera.main.ScreenPointToRay(screenPos);
+            RaycastHit hit;
+            hitTestResult = null;
+            if(Physics.Raycast(ray, out hit)){
+                hitTestResult = new HitTestResult()
+                {
+                    position = hit.point,
+                    rotation = hit.transform.rotation
+                };
+                return true;
+            }
+
+            return false;
+
+        }
     }
 }

--- a/Assets/UnityARInterface/Scripts/ARInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARInterface.cs
@@ -35,11 +35,12 @@ namespace UnityARInterface
             AmbientColorTemperature = 1 << 1,
         }
 
+        [Flags]
         public enum HitTestResultType
         {
             FeaturePoint = 0,
             PlaneWithinInfinity = 1,
-            PlaneWithinExtents = 2,
+            PlaneWithinBoxExtents = 2,
         }
 
         public class HitTestResult
@@ -87,6 +88,8 @@ namespace UnityARInterface
         public abstract bool TryGetCameraImage(ref CameraImage cameraImage);
 
         public abstract bool TryGetPointCloud(ref PointCloud pointCloud);
+
+        public abstract bool NativeHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes);
 
         public abstract LightEstimate GetLightEstimate();
 
@@ -136,16 +139,14 @@ namespace UnityARInterface
             return m_Interface;
         }
 
-        public static bool HitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
-        {
-            return m_Interface.RunHitTest(screenPos, out hitTestResult, hitTestResultTypes);
-        }
-
-        public abstract bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes);
-
         public static void SetInterface(ARInterface arInterface)
         {
             m_Interface = arInterface;
+        }
+
+        public static bool HitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        {
+            return m_Interface.NativeHitTest(screenPos, out hitTestResult, hitTestResultTypes);
         }
     }
 }

--- a/Assets/UnityARInterface/Scripts/ARInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARInterface.cs
@@ -35,6 +35,19 @@ namespace UnityARInterface
             AmbientColorTemperature = 1 << 1,
         }
 
+        public enum HitTestResultType
+        {
+            FeaturePoint = 0,
+            PlaneWithinInfinity = 1,
+            PlaneWithinExtents = 2,
+        }
+
+        public class HitTestResult
+        {
+            public Vector3 position;
+            public Quaternion rotation;
+        }
+
         public struct LightEstimate
         {
             public LightEstimateCapabilities capabilities;
@@ -122,6 +135,13 @@ namespace UnityARInterface
 
             return m_Interface;
         }
+
+        public static bool HitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        {
+            return m_Interface.RunHitTest(screenPos, out hitTestResult, hitTestResultTypes);
+        }
+
+        public abstract bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes);
 
         public static void SetInterface(ARInterface arInterface)
         {

--- a/Assets/UnityARInterface/Scripts/ARKitInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARKitInterface.cs
@@ -376,5 +376,62 @@ namespace UnityARInterface
                 arAnchor.anchorID = null;
             }
         }
+
+        private ARHitTestResultType[] GetARHitTestResultType(List<HitTestResultType> hitTypes)
+        {
+            List<ARHitTestResultType> nativeFlags = new List<ARHitTestResultType>();
+            foreach (HitTestResultType flag in hitTypes)
+            {
+                switch (flag)
+                {
+                    case HitTestResultType.FeaturePoint:
+                        nativeFlags.Add(ARHitTestResultType.ARHitTestResultTypeFeaturePoint);
+                        break;
+                    case HitTestResultType.PlaneWithinExtents:
+                        nativeFlags.Add(ARHitTestResultType.ARHitTestResultTypeExistingPlaneUsingExtent);
+                        break;
+                    case HitTestResultType.PlaneWithinInfinity:
+                        nativeFlags.Add(ARHitTestResultType.ARHitTestResultTypeExistingPlane);
+                        break;
+                }
+            }
+            nativeFlags.Add(ARHitTestResultType.ARHitTestResultTypeHorizontalPlane);
+            return nativeFlags.ToArray();
+        }
+
+        public override bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        {
+            var viewPortPoint = Camera.main.ScreenToViewportPoint(screenPos);
+
+            ARPoint point = new ARPoint
+            {
+                x = viewPortPoint.x,
+                y = viewPortPoint.y
+            };
+
+            // prioritize reults types
+            ARHitTestResultType[] resultTypes = GetARHitTestResultType(hitTestResultTypes);
+         
+            hitTestResult = null;
+            foreach (ARHitTestResultType resultType in resultTypes)
+            {
+                List<ARHitTestResult> hitResults = UnityARSessionNativeInterface.GetARSessionNativeInterface().HitTest(point, resultType);
+
+                if (hitResults.Count > 0)
+                {
+                    foreach (var hitResult in hitResults)
+                    {
+
+                        hitTestResult = new HitTestResult
+                        {
+                            position = UnityARMatrixOps.GetPosition(hitResult.worldTransform),
+                            rotation = UnityARMatrixOps.GetRotation(hitResult.worldTransform)
+                        };
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
     }
 }

--- a/Assets/UnityARInterface/Scripts/ARKitInterface.cs
+++ b/Assets/UnityARInterface/Scripts/ARKitInterface.cs
@@ -387,7 +387,7 @@ namespace UnityARInterface
                     case HitTestResultType.FeaturePoint:
                         nativeFlags.Add(ARHitTestResultType.ARHitTestResultTypeFeaturePoint);
                         break;
-                    case HitTestResultType.PlaneWithinExtents:
+                    case HitTestResultType.PlaneWithinBoxExtents:
                         nativeFlags.Add(ARHitTestResultType.ARHitTestResultTypeExistingPlaneUsingExtent);
                         break;
                     case HitTestResultType.PlaneWithinInfinity:
@@ -399,7 +399,7 @@ namespace UnityARInterface
             return nativeFlags.ToArray();
         }
 
-        public override bool RunHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
+        public override bool NativeHitTest(Vector2 screenPos, out HitTestResult hitTestResult, List<HitTestResultType> hitTestResultTypes)
         {
             var viewPortPoint = Camera.main.ScreenToViewportPoint(screenPos);
 

--- a/Assets/UnityARInterface/Scripts/ARPlaneVisualizer.cs
+++ b/Assets/UnityARInterface/Scripts/ARPlaneVisualizer.cs
@@ -6,11 +6,13 @@ namespace UnityARInterface
 {
     public class ARPlaneVisualizer : ARBase
     {
+        public static ARPlaneVisualizer instance;
+
         [SerializeField]
         private GameObject m_PlanePrefab;
 
         [SerializeField]
-        private int m_PlaneLayer;
+        internal int m_PlaneLayer;
 
         public int planeLayer { get { return m_PlaneLayer; } }
 
@@ -22,6 +24,8 @@ namespace UnityARInterface
             ARInterface.planeAdded += PlaneAddedHandler;
             ARInterface.planeUpdated += PlaneUpdatedHandler;
             ARInterface.planeRemoved += PlaneRemovedHandler;
+
+            instance = this;
         }
 
         void OnDisable()


### PR DESCRIPTION
Implemented a common way to do hitTest with both ARCore and ARKit. While both frameworks has some difference in capabilities they both have in common to detect horizontal planes and featurepoints.

My suggestion is to have these categories:
```
| ARInterface.HitTestResultType | ARKit.ARHitTestResultType                   | ARCore.TrackableHitFlags |
| ------------------------------|---------------------------------------------|--------------------------|
| FeaturePoint                  | ARHitTestResultTypeFeaturePoint             | FeaturePoint             |
| PlaneWithinBoxExtents         | ARHitTestResultTypeExistingPlaneUsingExtent | PlaneWithinBounds        |
| PlaneWithinInfinity           | ARHitTestResultTypeExistingPlane            | PlaneWithinInfinity      |
```
To call the HitTest you do something similar to:
```c#ARInterface.HitTestResult result;
            if (ARInterface.HitTest(Input.mousePosition, out result, new List<ARInterface.HitTestResultType>() { ARInterface.HitTestResultType.PlaneWithinBoxExtents }))
            {
                m_ObjectToPlace.transform.position = result.position;
                m_ObjectToPlace.transform.rotation = result.rotation;
            }
```

Current implementation doesn't have the RemoteEditorImplemented. If anyone Have time to do it I would be happy.

I have been running this code for a while in our own development to make one project to work on both iOS and Android which I think is a quite neat solution.